### PR TITLE
新实现mul等13条指令

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 build/
+*.txt

--- a/include/cpu/reg.h
+++ b/include/cpu/reg.h
@@ -5,6 +5,7 @@
 
 typedef struct {
   uint32_t gpr[32];
+  uint32_t hi, lo;
   vaddr_t pc;
 } CPU_state;
 

--- a/src/cpu/exec/exec.c
+++ b/src/cpu/exec/exec.c
@@ -115,6 +115,15 @@ void mult(vaddr_t *pc, uint32_t instr) {
 	sprintf(asm_buf_p, "mult %s,%s", regs[rs], regs[rt]);
 }
 
+void div(vaddr_t *pc, uint32_t instr) {
+	uint32_t rs, rt, dummy1, dummy2;
+	decode_r_format(instr, &rs, &rt, &dummy1, &dummy2);
+	assert(dummy1 == 0 && dummy2 == 0);
+	cpu.lo = (int32_t)cpu.gpr[rs] / (int32_t)cpu.gpr[rt];
+	cpu.hi = (int32_t)cpu.gpr[rs] % (int32_t)cpu.gpr[rt];
+	sprintf(asm_buf_p, "div %s,%s", regs[rs], regs[rt]);
+}
+
 void sltu(vaddr_t *pc, uint32_t instr) {
 	uint32_t rs, rt, rd, dummy;
 	decode_r_format(instr, &rs, &rt, &rd, &dummy);
@@ -381,7 +390,7 @@ exec_func gp0_table[64] = {
   /* 0x0c */	inv, inv, inv, inv,
   /* 0x10 */	mfhi, inv, mflo, inv,
   /* 0x14 */	inv, inv, inv, inv,
-  /* 0x18 */	mult, inv, inv, inv,
+  /* 0x18 */	mult, inv, div, inv,
   /* 0x1c */	inv, inv, inv, inv,
   /* 0x20 */	inv, addu, inv, subu,
   /* 0x24 */	and, or, xor, nor,

--- a/src/cpu/exec/exec.c
+++ b/src/cpu/exec/exec.c
@@ -402,7 +402,7 @@ void j(vaddr_t *pc, uint32_t instr) {
 	sprintf(asm_buf_p, "j %x", *pc);
 }
 
-exec_func gp0_table[64] = {
+exec_func special_table[64] = {
   /* 0x00 */    sll, inv, srl, sra,
   /* 0x04 */	sllv, inv, srlv, srav,
   /* 0x08 */	jr, jalr, movz, movn,
@@ -421,11 +421,11 @@ exec_func gp0_table[64] = {
   /* 0x3c */	inv, inv, inv, inv
 };
 
-void exec_gp0(vaddr_t *pc, uint32_t instr) {
-  gp0_table[get_funct(instr)](pc, instr);
+void exec_special(vaddr_t *pc, uint32_t instr) {
+  special_table[get_funct(instr)](pc, instr);
 }
 
-exec_func gp2_table[64] = {
+exec_func special2_table[64] = {
   /* 0x00 */    inv, inv, mul, inv,
   /* 0x04 */	inv, inv, inv, inv,
   /* 0x08 */	inv, inv, inv, inv,
@@ -444,19 +444,19 @@ exec_func gp2_table[64] = {
   /* 0x3c */	inv, inv, inv, inv
 };
 
-void exec_gp2(vaddr_t *pc, uint32_t instr) {
-  gp2_table[get_funct(instr)](pc, instr);
+void exec_special2(vaddr_t *pc, uint32_t instr) {
+  special2_table[get_funct(instr)](pc, instr);
 }
 
 exec_func opcode_table[64] = {
-  /* 0x00 */    exec_gp0, inv, j, jal,
+  /* 0x00 */    exec_special, inv, j, jal,
   /* 0x04 */	beq, bne, blez, inv,
   /* 0x08 */	inv, addiu, slti, sltiu,
   /* 0x0c */	andi, ori, xori, lui,
   /* 0x10 */	inv, inv, inv, inv,
   /* 0x14 */	inv, inv, inv, inv,
   /* 0x18 */	inv, inv, inv, inv,
-  /* 0x1c */	exec_gp2, inv, inv, inv,
+  /* 0x1c */	exec_special2, inv, inv, inv,
   /* 0x20 */	lb, lh, inv, lw,
   /* 0x24 */	lbu, lhu, inv, inv,
   /* 0x28 */	sb, sh, inv, sw,

--- a/src/cpu/exec/exec.c
+++ b/src/cpu/exec/exec.c
@@ -97,6 +97,14 @@ void subu(vaddr_t *pc, uint32_t instr) {
 	sprintf(asm_buf_p, "subu %s,%s,%s", regs[rd], regs[rs], regs[rt]);
 }
 
+void mul(vaddr_t *pc, uint32_t instr) {
+	uint32_t rs, rt, rd, dummy;
+	decode_r_format(instr, &rs, &rt, &rd, &dummy);
+	assert(dummy == 0);
+	cpu.gpr[rd] = cpu.gpr[rs] * cpu.gpr[rt];
+	sprintf(asm_buf_p, "mul %s,%s,%s", regs[rd], regs[rs], regs[rt]);
+}
+
 void sltu(vaddr_t *pc, uint32_t instr) {
 	uint32_t rs, rt, rd, dummy;
 	decode_r_format(instr, &rs, &rt, &rd, &dummy);
@@ -356,6 +364,29 @@ void exec_gp0(vaddr_t *pc, uint32_t instr) {
   gp0_table[get_funct(instr)](pc, instr);
 }
 
+exec_func gp2_table[64] = {
+  /* 0x00 */    inv, inv, mul, inv,
+  /* 0x04 */	inv, inv, inv, inv,
+  /* 0x08 */	inv, inv, inv, inv,
+  /* 0x0c */	inv, inv, inv, inv,
+  /* 0x10 */	inv, inv, inv, inv,
+  /* 0x14 */	inv, inv, inv, inv,
+  /* 0x18 */	inv, inv, inv, inv,
+  /* 0x1c */	inv, inv, inv, inv,
+  /* 0x20 */	inv, inv, inv, inv,
+  /* 0x24 */	inv, inv, inv, inv,
+  /* 0x28 */	inv, inv, inv, inv,
+  /* 0x2c */	inv, inv, inv, inv,
+  /* 0x30 */	inv, inv, inv, inv,
+  /* 0x34 */	inv, inv, inv, inv,
+  /* 0x38 */	inv, inv, inv, inv,
+  /* 0x3c */	inv, inv, inv, inv
+};
+
+void exec_gp2(vaddr_t *pc, uint32_t instr) {
+  gp2_table[get_funct(instr)](pc, instr);
+}
+
 exec_func opcode_table[64] = {
   /* 0x00 */    exec_gp0, inv, inv, jal,
   /* 0x04 */	beq, bne, inv, inv,
@@ -364,7 +395,7 @@ exec_func opcode_table[64] = {
   /* 0x10 */	inv, inv, inv, inv,
   /* 0x14 */	inv, inv, inv, inv,
   /* 0x18 */	inv, inv, inv, inv,
-  /* 0x1c */	inv, inv, inv, inv,
+  /* 0x1c */	exec_gp2, inv, inv, inv,
   /* 0x20 */	lb, lh, inv, lw,
   /* 0x24 */	lbu, lhu, inv, inv,
   /* 0x28 */	sb, sh, inv, sw,

--- a/src/cpu/exec/exec.c
+++ b/src/cpu/exec/exec.c
@@ -137,6 +137,30 @@ void sra(vaddr_t *pc, uint32_t instr) {
 	sprintf(asm_buf_p, "sra %s,%s,0x%x", regs[rd], regs[rt], sa);
 }
 
+void srav(vaddr_t *pc, uint32_t instr) {
+	uint32_t rs, rt, rd, dummy;
+	decode_r_format(instr, &rs, &rt, &rd, &dummy);
+	assert(dummy == 0);
+	cpu.gpr[rd] = (int32_t)cpu.gpr[rt] >> (cpu.gpr[rs] & 0x1f);
+	sprintf(asm_buf_p, "srav %s,%s,%s", regs[rd], regs[rt], regs[rs]);
+}
+
+void srl(vaddr_t *pc, uint32_t instr) {
+	uint32_t rs, rt, rd, sa;
+	decode_r_format(instr, &rs, &rt, &rd, &sa);
+	assert(rs == 0);
+	cpu.gpr[rd] = cpu.gpr[rt] >> sa;
+	sprintf(asm_buf_p, "srl %s,%s,0x%x", regs[rd], regs[rt], sa);
+}
+
+void srlv(vaddr_t *pc, uint32_t instr) {
+	uint32_t rs, rt, rd, dummy;
+	decode_r_format(instr, &rs, &rt, &rd, &dummy);
+	assert(dummy == 0);
+	cpu.gpr[rd] = cpu.gpr[rt] >> (cpu.gpr[rs] & 0x1f);
+	sprintf(asm_buf_p, "srlv %s,%s,%s", regs[rd], regs[rt], regs[rs]);
+}
+
 void movn(vaddr_t *pc, uint32_t instr) {
 	uint32_t rs, rt, rd, dummy;
 	decode_r_format(instr, &rs, &rt, &rd, &dummy);
@@ -310,8 +334,8 @@ void jal(vaddr_t *pc, uint32_t instr) {
 }
 
 exec_func gp0_table[64] = {
-  /* 0x00 */    sll, inv, inv, sra,
-  /* 0x04 */	sllv, inv, inv, inv,
+  /* 0x00 */    sll, inv, srl, sra,
+  /* 0x04 */	sllv, inv, srlv, srav,
   /* 0x08 */	jr, inv, movz, movn,
   /* 0x0c */	inv, inv, inv, inv,
   /* 0x10 */	inv, inv, inv, inv,

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -60,7 +60,7 @@ static inline void restart() {
 
 static inline void parse_args(int argc, char *argv[]) {
   int o;
-  while ( (o = getopt(argc, argv, "-bli:")) != -1) {
+  while ( (o = getopt(argc, argv, "-bl:i:")) != -1) {
     switch (o) {
       case 'b': is_batch_mode = true; break;
       case 'l': log_file = optarg; break;


### PR DESCRIPTION
## 目前实现了45条指令
加粗的为本次新实现的指令
### Arithmetic Instructions
addu, subu, addiu, **mul, mult, div, divu**
### Logical Instructions
or, xor, and, nor, ori, andi, xori, sll, sra, sllv, **srl, srav, srlv**
### Control Flow Instructions
**j**, jr, jal, **jalr**, beq, bne, **blez, bltz**, sltiu, sltu, slt, slti
### Memory Instructions
sw, sh, sb
lw, lh, lhu, lb, lbu
### Misc
lui, movn, movz, **mfhi, mflo**

## 测试用例
已通过除unalign外cputest中的所有测试用例